### PR TITLE
Fixes license key bash command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To setup New Relic:
 1. Update your Heroku NEW_RELIC_LICENSE_KEY config variable via command line (find your New Relic license key under Account Settings)
 
     ```bash
-    heroku config:set NEW_RELIC_APP_NAME=enter-license-key-here
+    heroku config:set NEW_RELIC_LICENSE_KEY=enter-license-key-here
     ```
 
 1. View your New Relic dashboard - you should see your app name there.

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -224,4 +224,4 @@ production:
 staging:
   <<: *default_settings
   monitor_mode: true
-  # app_name: My Application (Staging)
+  app_name: <%= ENV["NEW_RELIC_APP_NAME"] %> (Staging)

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -15,7 +15,7 @@ common: &default_settings
   # You must specify the license key associated with your New Relic
   # account.  This key binds your Agent's data to your account in the
   # New Relic service.
-  license_key: <%= ENV["NEW_RELIC_KEY"] %>
+  license_key: <%= ENV["NEW_RELIC_LICENSE_KEY"] %>
 
   # Agent Enabled (Ruby/Rails Only)
   # Use this setting to force the agent to run or not run.


### PR DESCRIPTION
Hi, jessicard.

Just a small fix to the README and newrelic.yml to use `NEW_RELIC_LICENSE_KEY`. Also removed an empty .gitignore that was in public/img/.

This is the best writeup I've seen on how to get New Relic to play nice with a Rack app. Still having trouble getting Availability Monitoring set up, though. Trying to access it from my control panel on New Relic's site keeps redirecting to their errors page. :-/ 

In any case, great example app!

Cheers,
O-I
